### PR TITLE
Break long title in new line #11( solved css issue )

### DIFF
--- a/assets/scss/_header.scss
+++ b/assets/scss/_header.scss
@@ -1,6 +1,7 @@
 header {
   > h1 {
     margin: 0;
+    overflow-wrap: break-word;
 
     > a:hover {
       text-decoration: none;


### PR DESCRIPTION
##  Due to non handling of overflown text caused by h1 

### This works the best to break the line and wrap
- [x]  `overflow-wrap: break-word;`

> So I have updated the header.scss file to inlcude this line at the appropriate place which is a h1 tag inside a header tag.

@midzer  thank you for defining exact issue very clearly.