### PR TITLE
Fixed the Break long title in new line.

### DIFF
--- a/assets/scss/_header.scss
+++ b/assets/scss/_header.scss
@@ -1,11 +1,16 @@
 header {
+
+
+
   > h1 {
     margin: 0;
     overflow-wrap: break-word;
+    
 
     > a:hover {
       text-decoration: none;
     }
+
   }
   > div {
     margin-top: 1rem;

--- a/assets/scss/_header.scss
+++ b/assets/scss/_header.scss
@@ -1,6 +1,7 @@
 header {
   > h1 {
     margin: 0;
+    overflow-wrap: break-word;
 
     > a:hover {
       text-decoration: none;


### PR DESCRIPTION
Hey, 
The issue Break long title in new line just has fixed by added `overflow-wrap: break-word; ` in  **assets/scss/_header.scss** file.
